### PR TITLE
Minor comment and package.json fixes

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -2,18 +2,19 @@ var wreck   = require('wreck');
 var cheerio = require('cheerio');
 
 /**
- * repo method scrapes a given GitHub user's repositories tab
- * @param {string} username - a valid GitHub username
+ * repo method scrapes a given GitHub repository page
+ * @param {string} project - a valid GitHub repository name
  * @param {function} callback - the callback we should call after scraping
  *  a callback passed into this method should accept two parameters:
- *  @param {objectj} error an error object (set to null if no error occurred)
- *  @param {array} repos - list of (Public) GitHub repositories (for the user)
+ *  @param {object} error - an error object (set to null if no error occurred)
+ *  @param {array} stats - list of (Public) information on the GitHub repository
  */
+ 
 function repo (project, callback) {
   if(!project || project.length === 0 || typeof project === 'undefined'){
     return callback(400);
   }
-  var url = 'https://github.com/' + project+ '?tab=repositories'
+  var url = 'https://github.com/' + project;
   wreck.get(url, function (error, response, html) {
     if (error || response.statusCode !== 200) {
       callback(response.statusCode);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "url": "https://github.com/nelsonic/github-scraper/issues"
   },
   "homepage": "https://github.com/nelsonic/github-scraper",
+  "engines": {
+    "node": ">= 0.12"
+  },
   "dependencies": {
     "cheerio": "^0.19.0",
     "request": "^2.60.0",


### PR DESCRIPTION
This pull request:
+ Alters the @param comments in `repo.js` to accurately reflect what the `repo` function does
+ Removes unnecessary `?tab=repositories` from url path
+ Adds node version to package.json to make sure tests pass (as a by-product of the above)

Fixes https://github.com/nelsonic/github-scraper/issues/16