### PR TITLE
add 'forked from' url to repo data if present

### DIFF
--- a/lib/repo.js
+++ b/lib/repo.js
@@ -14,6 +14,10 @@ function repo ($, url, callback) {
   data.website  = $('.repository-website').text().trim();
   var badges = $('.social-count');
   // console.log(badges);
+  var forkedfrom = $('.fork-flag > span > a').attr('href');
+  if (forkedfrom) {
+    data.forkedfrom = forkedfrom;
+  }
   data.watchers = parseInt(badges['0'].children[0].data.trim(), 10);
   data.stars    = parseInt(badges['1'].children[0].data.trim(), 10);
   data.forks    = parseInt(badges['2'].children[0].data.trim(), 10);

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -6,7 +6,7 @@ test('Scrape @nelsonic GitHub profile (consistent state profile)', function(t){
 	profile(user, function(err, data){
 		// console.log(data)
 
-		t.ok(data.img === 'https://avatars3.githubusercontent.com/u/194400?v=3&s=460',
+		t.ok(data.img.match(/https:\/\/avatars\d+.githubusercontent.com\/u\/194400\?v=\d+&s=460/) !== null,
 		'Image is what we expect: ' + data.img);
 		t.ok(data.uid === 194400, '@' + user + ' has GitHub user_id: ' + data.uid);
 

--- a/test/repo.test.js
+++ b/test/repo.test.js
@@ -30,3 +30,11 @@ test('crawl ZERO language repo', function(t){
 		t.end();
 	})
 })
+
+test('crawl forked repo', function(t){
+  var project = '/backhand/github-scraper';
+  repo(project, function(err, stats) {
+    t.ok(stats.forkedfrom === '/nelsonic/github-scraper', 'Repo forked from /nelsonic/github-scraper')
+    t.end();
+  })
+})


### PR DESCRIPTION
Implement scraping the url the repo was forked from, if it's there. If not, no property will be added to the data object. This makes it easy to determine both if a repo was forked, as well as from where.